### PR TITLE
Disable initial connection timeout

### DIFF
--- a/src/main/java/com/lauriewired/malimite/decompile/GhidraProject.java
+++ b/src/main/java/com/lauriewired/malimite/decompile/GhidraProject.java
@@ -46,7 +46,7 @@ public class GhidraProject {
     public void decompileMacho(String executableFilePath, String projectDirectoryPath, Macho targetMacho) {
         LOGGER.info("Starting Ghidra decompilation for: " + executableFilePath);
         try (ServerSocket serverSocket = new ServerSocket(PORT)) {
-            serverSocket.setSoTimeout(300000); // 5 minute timeout for initial connection
+            serverSocket.setSoTimeout(0); // no timeout for initial connection
 
             String analyzeHeadless = getAnalyzeHeadlessPath();
             


### PR DESCRIPTION
When attempting to decompile the [DVIA app](https://github.com/prateek147/DVIA-v2), analysis alone takes >240 seconds, which causes the initial connection from the Ghidra script to timeout and fail, even when analysis is successful. This PR removes that initial timeout, making it possible for larger IPAs to be loaded into Malimite

```
Ghidra Output: INFO  -----------------------------------------------------
Ghidra Output:     AARCH64 ELF PLT Thunks                     0.000 secs
Ghidra Output:     ASCII Strings                              0.685 secs
Ghidra Output:     Apply Data Archives                        0.399 secs
Ghidra Output:     Basic Constant Reference Analyzer         20.912 secs
Ghidra Output:     CFStrings                                  0.204 secs
Ghidra Output:     Call Convention ID                        23.334 secs
Ghidra Output:     Call-Fixup Installer                       0.123 secs
Ghidra Output:     Create Address Tables                      0.696 secs
Ghidra Output:     Create Address Tables - One Time           0.518 secs
Ghidra Output:     Create Function                            0.281 secs
Ghidra Output:     Data Reference                             1.537 secs
Ghidra Output:     Decompiler Switch Analysis                11.741 secs
Ghidra Output:     Decompiler Switch Analysis - One Time      4.718 secs
Ghidra Output:     Demangler GNU                              0.551 secs
Ghidra Output:     Demangler Swift                           87.051 secs
Ghidra Output:     Disassemble                                0.966 secs
Ghidra Output:     Disassemble Entry Points                   2.023 secs
Ghidra Output:     Disassemble Entry Points - One Time        0.648 secs
Ghidra Output:     Embedded Media                             0.072 secs
Ghidra Output:     External Entry References                  0.042 secs
Ghidra Output:     Function Start Search                      0.296 secs
Ghidra Output:     Function Start Search After Code           0.284 secs
Ghidra Output:     Function Start Search After Data           0.268 secs
Ghidra Output:     Function Start Search delayed - One Time   0.269 secs
Ghidra Output:     Mach-O Function Starts                     0.882 secs
Ghidra Output:     Non-Returning Functions - Discovered       1.866 secs
Ghidra Output:     Non-Returning Functions - Known            0.069 secs
Ghidra Output:     Objective-C 2 Class                       12.425 secs
Ghidra Output:     Objective-C 2 Decompiler Message          42.294 secs
Ghidra Output:     Reference                                  0.760 secs
Ghidra Output:     Shared Return Calls                        1.635 secs
Ghidra Output:     Stack                                     29.089 secs
Ghidra Output:     Subroutine References                      0.559 secs
Ghidra Output:     Subroutine References - One Time           0.000 secs
Ghidra Output:     Swift Type Metadata Analyzer               0.039 secs
Ghidra Output: -----------------------------------------------------
Ghidra Output:      Total Time   247 secs
Ghidra Output: -----------------------------------------------------
Ghidra Output:  (AutoAnalysisManager)
Ghidra Output: INFO  REPORT: Analysis succeeded for file: file:///Users/teknogeek/Downloads/DVIA-v2_malimite/DVIA-v2 (HeadlessAnalyzer)
Ghidra Output: INFO  SCRIPT: /Users/teknogeek/Downloads/Malimite/DecompilerBridge/ghidra/DumpClassData.java (HeadlessAnalyzer)
Ghidra Output: Running DumpCombinedData script
Ghidra Output: WARN  Decompiling 1007f4c70, pcode error at 1007f4c70: Unable to disassemble EXTERNAL block location: 1007f4c70 (DecompileCallback)
Ghidra Output: WARN  Decompiling 1007f4c50, pcode error at 1007f4c50: Unable to disassemble EXTERNAL block location: 1007f4c50 (DecompileCallback)
Ghidra Output: WARN  Decompiling 1007f4c58, pcode error at 1007f4c58: Unable to disassemble EXTERNAL block location: 1007f4c58 (DecompileCallback)
Ghidra Output: WARN  Decompiling 1007f4c60, pcode error at 1007f4c60: Unable to disassemble EXTERNAL block location: 1007f4c60 (DecompileCallback)
Dec 10, 2024 6:34:01 AM com.lauriewired.malimite.decompile.GhidraProject decompileMacho
SEVERE: Error during Ghidra decompilation
java.net.SocketTimeoutException: Accept timed out
	at java.base/java.net.PlainSocketImpl.socketAccept(Native Method)
	at java.base/java.net.AbstractPlainSocketImpl.accept(AbstractPlainSocketImpl.java:474)
	at java.base/java.net.ServerSocket.implAccept(ServerSocket.java:576)
	at java.base/java.net.ServerSocket.accept(ServerSocket.java:539)
	at com.lauriewired.malimite.decompile.GhidraProject.decompileMacho(GhidraProject.java:91)
	at com.lauriewired.malimite.ui.AnalysisWindow$4.doInBackground(AnalysisWindow.java:929)
	at com.lauriewired.malimite.ui.AnalysisWindow$4.doInBackground(AnalysisWindow.java:859)
	at java.desktop/javax.swing.SwingWorker$1.call(SwingWorker.java:304)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.desktop/javax.swing.SwingWorker.run(SwingWorker.java:343)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```