### PR TITLE
Improve analysis speed (closes #8)

### DIFF
--- a/src/main/java/com/lauriewired/malimite/decompile/GhidraProject.java
+++ b/src/main/java/com/lauriewired/malimite/decompile/GhidraProject.java
@@ -225,7 +225,7 @@ public class GhidraProject {
                         }
                         
                         // Store function decompilation with the correct class name and executable name
-                        dbHandler.updateFunctionDecompilation(functionName, className, decompiledCode, targetMacho.getMachoExecutableName());
+                        dbHandler.updateFunctionDecompilation(dbHandler.GetTransaction(), functionName, className, decompiledCode, targetMacho.getMachoExecutableName());
                         
                         // Add to class functions map
                         classToFunctions.computeIfAbsent(className, k -> new JSONArray())
@@ -243,7 +243,7 @@ public class GhidraProject {
                         // Store the mapping of original class name to "Libraries"
                         classNameMapping.put(className, "Libraries");
                         
-                        dbHandler.updateFunctionDecompilation(libraryFunctionName, "Libraries", targetMacho.getMachoExecutableName(), targetMacho.getMachoExecutableName());
+                        dbHandler.updateFunctionDecompilation(dbHandler.GetTransaction(), libraryFunctionName, "Libraries", targetMacho.getMachoExecutableName(), targetMacho.getMachoExecutableName());
                         
                         // Add to class functions map under "Libraries"
                         classToFunctions.computeIfAbsent("Libraries", k -> new JSONArray())

--- a/src/main/java/com/lauriewired/malimite/decompile/SyntaxParser.java
+++ b/src/main/java/com/lauriewired/malimite/decompile/SyntaxParser.java
@@ -95,6 +95,7 @@ public class SyntaxParser {
 
                 // Store the function reference with adjusted line number
                 dbHandler.insertFunctionReference(
+                    dbHandler.GetTransaction(),
                     currentFunction,
                     currentClass,
                     calledFunction,
@@ -137,6 +138,7 @@ public class SyntaxParser {
                         
                         // Store the type information
                         dbHandler.insertTypeInformation(
+                            dbHandler.GetTransaction(),
                             variableName,
                             variableType,
                             currentFunction,
@@ -147,6 +149,7 @@ public class SyntaxParser {
 
                         // Store initial local variable reference
                         dbHandler.insertLocalVariableReference(
+                            dbHandler.GetTransaction(),
                             variableName,
                             currentFunction,
                             currentClass,
@@ -173,6 +176,7 @@ public class SyntaxParser {
                 
                 // Store class usage reference
                 dbHandler.insertFunctionReference(
+                    dbHandler.GetTransaction(),
                     currentFunction,
                     currentClass,
                     null,  // No specific function
@@ -186,6 +190,7 @@ public class SyntaxParser {
                 // Check if this identifier is in a function call context
                 if (!isPartOfFunctionCall(ctx)) {
                     dbHandler.insertLocalVariableReference(
+                        dbHandler.GetTransaction(),
                         identifier,
                         currentFunction,
                         currentClass,


### PR DESCRIPTION
Wrap multiple SQL statements in a single transaction and share the database connection to drastically speed up the write speed of the function decompilaton results during the initial analysis.

This is a simple initial solution to the problem, perhaps you want to handle it differently. My suggestions to improve this further (perhaps as a later step through another PR) would be to:
- Decouple the `SyntaxParser` from the `SQLiteDBHandler` so you don't need to pass in the connection as an argument every time. We could work with callbacks instead and let the `SQLiteDBHandler` handle all the database operations.
- Add multi-threading. This idea should be trialed further, but I think it may be possible to execute `updateFunctionDecompilation` in another thread, so the `SyntaxParser` can do its work in the background while the main thread moves on to the next function. Database operations should still be atomic, thanks to the added transactions.

I only tested these changes with one IPA file. Please verify that everything still works as expected before merging!

Fixes #8.